### PR TITLE
update instructions to point at correct repo.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,12 +26,12 @@ Github
 
 ::
 
-    pip install git+https://github.com/sivel/speedtest-cli-datadog.git
+    pip install git+https://github.com/foutoucour/speedtest-cli-datadog.git
 
 or
 
 ::
 
-    git clone https://github.com/sivel/speedtest-cli-datadog.git
+    git clone https://github.com/foutoucour/speedtest-cli-datadog.git
     python speedtest-cli-datadog/setup.py install
 

--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,19 @@
 speedtest-cli-datadog
 =====================
 
-Based on the work done on https://github.com/sivel/speedtest-cli to send data to datadog
+This CLI utility conducts a speedtest via [speedtest.net](http://www.speedtest.net] and emits the results via dogstatsd.
 
-Thank @jremond for the idea ;)
+This tool is based on [sivel/speedtest-cli][https://github.com/sivel/speedtest-cli].
+
+Thank [jremond](https://github.com/jremond) for the idea ;)
+
+Metrics
+------------
+This utility emits three metrics:
+
+* speedtest.upload 
+* speedtest.download
+* speedtest.latency
 
 Installation
 ------------


### PR DESCRIPTION
Updates to readme.

- Instructions were pointing at sivel/speedtest-cli rather than foutoucour/speedtest-cli-datadog. 
- Add list of metrics
- Update description.