### PR TITLE
Update to work with 1.0.0 release of speedtest-cli

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 datadog>=0.13.0
-speedtest_cli>=0.3.4
+speedtest_cli>=1.0.0

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ except:
 setup(
     install_requires=reqs,
     name='speedtest-cli-datadog',
-    version='0.1.0',
+    version='0.2.0',
     description=('Command line interface for testing internet bandwidth using '
                  'speedtest.net, using datadog statsd.'),
     long_description=long_description,

--- a/speedtest_cli_datadog.py
+++ b/speedtest_cli_datadog.py
@@ -3,9 +3,9 @@
 import logging
 import functools
 from datadog import statsd
-import speedtest_cli
+import speedtest
 
-log = logging.getLogger('speedtest_cli_datadog')
+log = logging.getLogger('speedtest_datadog')
 logging.basicConfig()
 log.setLevel(logging.DEBUG)
 
@@ -51,19 +51,21 @@ class DatadogGaugeLatency(DatadogGauge):
         return wrappee
 
 
-# Decoration of the functions of speedtest_cli
-speedtest_cli.downloadSpeed = DatadogGauge('speedtest.download')(
-    speedtest_cli.downloadSpeed
+# Decoration of the functions of speedtest
+speedtest.Speedtest.download = DatadogGauge('speedtest.download')(
+    speedtest.Speedtest.download
 )
-speedtest_cli.uploadSpeed = DatadogGauge('speedtest.upload')(
-    speedtest_cli.uploadSpeed
+
+speedtest.Speedtest.upload = DatadogGauge('speedtest.upload')(
+    speedtest.Speedtest.upload
 )
-speedtest_cli.getBestServer = DatadogGaugeLatency('speedtest.latency')(
-    speedtest_cli.getBestServer
+
+speedtest.Speedtest.get_best_server = DatadogGaugeLatency('speedtest.latency')(
+    speedtest.Speedtest.get_best_server
 )
 
 # required for the command line entry point.
-main = speedtest_cli.main
+main = speedtest.main
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Replace use of speedtest_cli 
* Recent releases of speedtest-cli deprecated the module speedtest-cli favor of speedtest
* Some minor changes in method / class names.
* Update requirements.txt to track new versions.